### PR TITLE
Fix visual bug with totem swapping on RMB click

### DIFF
--- a/Buttons.lua
+++ b/Buttons.lua
@@ -182,5 +182,6 @@ function Yatabar:ButtonClicked(arg1)
 		-- end
 
 		Yatabar:SetLayout()
+		Yatabar:HidePopups()
 	end
 end

--- a/Yatabar.lua
+++ b/Yatabar.lua
@@ -1337,7 +1337,9 @@ end
 function Yatabar:GetTotemSet()
 	local set = {}
 	for element, spells in pairs(Yatabar.orderTotemsInElement) do
-		table.insert(set, Yatabar.orderTotemsInElement[element][1].name)
+		if Yatabar.orderTotemsInElement[element][1] ~= nil then
+			table.insert(set, Yatabar.orderTotemsInElement[element][1].name)
+		end
 		--print("TotemSet:",element, Yatabar.orderTotemsInElement[element][1].name)
 	end
 	return set


### PR DESCRIPTION
Found one more issue, caused by a missing shaman's element.

So, when I tried to swap totems by clicking RMB on them here's what happened. First I had to click on a new totem and then click on the first one to make them swap.

https://user-images.githubusercontent.com/5385483/120067083-5f2d0700-c082-11eb-979c-2eb2c5b2b007.mp4

BugSack caught an error

![Screenshot_7_rmb](https://user-images.githubusercontent.com/5385483/120067106-871c6a80-c082-11eb-9e55-b7bfe7b75e35.png)

I checked `orderTotemsInElement` table and the inner 'AIR' table was empty, cause I still didn't have any air totems. So I decided to add a nil check inside the `GetTotemSet()` function.

![Screenshot_8_rmb](https://user-images.githubusercontent.com/5385483/120067305-7d473700-c083-11eb-83b1-9eb1bf931bd0.png)

```lua
function Yatabar:GetTotemSet()
    local set = {}
    for element, spells in pairs(Yatabar.orderTotemsInElement) do
        if Yatabar.orderTotemsInElement[element][1] ~= nil then
            table.insert(set, Yatabar.orderTotemsInElement[element][1].name)
        end
        --print("TotemSet:",element, Yatabar.orderTotemsInElement[element][1].name)
    end
    return set
end
```
Now totems are swapping, when I click RMB on them but the popup menu stays on the screen and I need to hover it to make it disappear. 

https://user-images.githubusercontent.com/5385483/120067346-ae276c00-c083-11eb-84e5-11aac990ab5e.mp4

To fix it I simply called `HidePopups()` in `ButtonClicked(arg1)` function.

```lua
function Yatabar:ButtonClicked(arg1)
    if arg1 == "RightButton" and not InCombatLockdown() then
    ...
    Yatabar:HidePopups()
    end
end
```

https://user-images.githubusercontent.com/5385483/120067583-2c384280-c085-11eb-9612-68a3bb47d74e.mp4




